### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/whiskit-build.yml
+++ b/.github/workflows/whiskit-build.yml
@@ -1,0 +1,25 @@
+name: Whiskit
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repository contents
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Install dependencies
+      - name: Install apt dependencies
+        run: |
+          sudo apt update
+          sudo apt install libboost-all-dev freeglut3-dev mesa-utils
+      - name: Build Whiskit
+        run: |
+          mkdir whiskit-build
+          cd whiskit-build
+          cmake ${GITHUB_WORKSPACE}/code
+          make -j
+          sudo make install
+


### PR DESCRIPTION
This adds a basic continuous integration step to the repository. The CI will run on GitHub Actions and will be triggered by each new pull request. If Whiskit builds OK, the pull request gets a green checkmark.

In the future, further tests should be added to the CI run. As part of an upcoming PR adding support for YAML-based configuration files, also a (headless) run of Whiskit will be included.